### PR TITLE
feat: class 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/
 *.o
 isort
 *.dSYM
+*.ll

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ name = "bit_hacks_3"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "rand",
+ "rand 0.9.0-beta.1",
 ]
 
 [[package]]
@@ -215,6 +215,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a78f88e84d239c7f2619ae8b091603c26208e1cb322571f5a29d6806f56ee5e"
@@ -223,7 +234,7 @@ dependencies = [
  "js-sys",
  "libc",
  "rustix",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -306,7 +317,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 name = "matrix_mul_1"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.9.0-beta.1",
  "rayon",
 ]
 
@@ -394,13 +405,34 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8478de76992f2825a1052cc2ae9d1401cdb62687761d4100ddd69a73dc3dc48"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0-beta.1",
+ "rand_core 0.9.0-beta.1",
  "zerocopy 0.8.13",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -410,7 +442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16da77124f4ee9fabd55ce6540866e9101431863b4876de58b68797f331adf2"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.0-beta.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -419,7 +460,7 @@ version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.0-rc.0",
  "zerocopy 0.8.13",
 ]
 
@@ -476,7 +517,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rust"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.9.0-beta.1",
 ]
 
 [[package]]
@@ -582,6 +623,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
 version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
@@ -651,6 +698,13 @@ checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "what_compilers_can_and_cannot_do_9"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ members = ["classes/*", "homework/2_profiling/recitation/rust"]
 [workspace.dependencies]
 criterion = "0.5.1"
 rayon = "1.10.0"
+rand_core = "0.6.4"
+rand = "0.8.5"

--- a/classes/what_compilers_can_and_cannot_do_9/Cargo.toml
+++ b/classes/what_compilers_can_and_cannot_do_9/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "what_compilers_can_and_cannot_do_9"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand.workspace = true
+
+[[bin]]
+name = "nbody"
+path = "src/nbody.rs"

--- a/classes/what_compilers_can_and_cannot_do_9/Makefile
+++ b/classes/what_compilers_can_and_cannot_do_9/Makefile
@@ -1,0 +1,21 @@
+.PHONY: run-release run-debug llvm asm
+
+RUST_FLAGS :=
+OPT_LEVEL := 3
+
+run-release:
+	RUSTFLAGS="$(RUST_FLAGS) -C opt-level=$(OPT_LEVEL)" cargo run --release
+
+run-debug:
+	RUSTFLAGS="$(RUST_FLAGS)" cargo run --debug
+
+llvm:
+	RUSTFLAGS="--emit=llvm-ir -C opt-level=$(OPT_LEVEL)" cargo build
+	@echo "LLVM IR files in target/debug/deps/*.ll"
+
+asm:
+	RUSTFLAGS="--emit=asm -C opt-level=$(OPT_LEVEL)" cargo build
+	@echo "Assembly files in target/debug/deps/*.s"
+
+clean:
+	cargo clean

--- a/classes/what_compilers_can_and_cannot_do_9/c/Makefile
+++ b/classes/what_compilers_can_and_cannot_do_9/c/Makefile
@@ -1,0 +1,38 @@
+CC = /usr/bin/clang
+SRC := nbody.c
+TARGET := nbody.build
+OPT_LEVEL ?= 0
+
+CFLAGS := -Wall -Wextra
+LDFLAGS :=
+
+ifdef DEBUG
+	CFLAGS += -g -DDEBUG
+else
+	CFLAGS += -DNDEBUG
+endif
+
+.PHONY: all clean run ir asm
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) -O$(OPT_LEVEL) $< -o $@ $(LDFLAGS)
+
+ir: $(SRC)
+	$(CC) $(CFLAGS) -O$(OPT_LEVEL) -S -emit-llvm $< -o $(TARGET)_O$(OPT_LEVEL).ll
+
+asm: $(SRC)
+	$(CC) $(CFLAGS) -O$(OPT_LEVEL) -S $< -o $(TARGET)_O$(OPT_LEVEL).s
+
+run: $(TARGET)
+	./$(TARGET)
+
+clean:
+	rm -f $(TARGET) *.ll *.s
+
+
+#make OPT_LEVEL=2           # Compile with -O2
+#make DEBUG=1 OPT_LEVEL=1   # Debug build with -O1
+#make ir OPT_LEVEL=3        # Generate LLVM IR with -O3
+#make asm OPT_LEVEL=0       # Generate assembly with -O0

--- a/classes/what_compilers_can_and_cannot_do_9/c/nbody.c
+++ b/classes/what_compilers_can_and_cannot_do_9/c/nbody.c
@@ -1,0 +1,104 @@
+//
+// Created by Elvis Sabanovic on 30/12/2024.
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+// LAW OF GRAVITATION:
+// F_21 = (G m1m2/|r_12|^2) unit(r_21)
+
+typedef struct vect_t {
+  double x, y;
+} vec_t;
+
+static vec_t add(vec_t a, vec_t b) {
+  vec_t sum = { a.x + b.x, a.y + b.y };
+  return sum;
+}
+
+static vec_t scale(vec_t v, double a) {
+  vec_t scaled = { v.x * a, v.y * a };
+  return scaled;
+}
+
+static double vec_length2(vec_t v) {
+  return v.x * v.x + v.y * v.y;
+}
+
+typedef struct body_t {
+  vec_t position;
+  vec_t velocity;
+  vec_t force;
+  double mass;
+} body_t;
+
+void update_position(int nbodies, body_t *bodies, double time_quantum) {
+  for (int i = 0; i < nbodies; i++) {
+    // compute new veolicty for each body
+    vec_t new_velocity = scale(bodies[i].force, time_quantum / bodies[i].mass);
+
+    // update position of each body based on average based on it's old and new velocity
+    bodies[i].position = add(bodies[i].position, scale(add(bodies[i].velocity, new_velocity), time_quantum / 2.0));
+
+    // set new velocity of bodies
+    bodies[i].velocity = new_velocity;
+  }
+}
+
+//void calculate_forces(int nbodies, body_t *bodies) {
+//  for (int i = 0; i < nbodies; i++) {
+//    for (int j = 0; j < nbodies; j++) {
+//      if (i == j) continue;
+//
+//      add_force(&bodies[i], calculate_force(&bodies[i], &bodies[j]));
+//    }
+//  }
+//}
+
+//void calculate_forces(int nbodies, body_t *bodies) {
+//  for (int i = 0; i < nbodies; i++) {
+//    This change computes address on each j loop
+//    we can hoist it to compute only when i ticks and re-use it in j loop
+//    body_t *bi = &bodies[i];
+//    for (int j = 0; j < nbodies; j++) {
+//      if (i == j) continue;
+//
+//      add_force(body_t, calculate_force(body_t, &bodies[j]));
+//    }
+//  }
+//}
+
+void simulate(body_t *bodies, int nbodies, int nsteps, double time_quantum) {
+  for (int i = 0; i < nbodies; i++) {
+//    calculate_forces(nbodies, bodies);
+    update_position(nbodies, bodies, time_quantum);
+  }
+}
+
+int main() {
+  srand(time(NULL));
+  const int nbodies = 3;
+  const int nsteps = 100;
+  const double time_quantum = 0.1;
+
+  body_t bodies[nbodies];
+
+  // Initialize random bodies
+  for (int i = 0; i < nbodies; i++) {
+    bodies[i] = (body_t){
+      .position = {(double)rand()/RAND_MAX * 20 - 10, (double)rand()/RAND_MAX * 20 - 10},
+      .velocity = {0, 0},
+      .force = {0, 0},
+      .mass = (double)rand()/RAND_MAX * 100
+  };
+  }
+
+  simulate(bodies, nbodies, nsteps, time_quantum);
+
+  for (int i = 0; i < nbodies; i++) {
+    printf("Body %d: Position (%.2f, %.2f)\n", i, bodies[i].position.x, bodies[i].position.y);
+  }
+
+  return 0;
+}

--- a/classes/what_compilers_can_and_cannot_do_9/src/nbody.rs
+++ b/classes/what_compilers_can_and_cannot_do_9/src/nbody.rs
@@ -1,0 +1,85 @@
+use rand::Rng;
+
+#[derive(Debug, Clone, Copy)]
+struct Vec2 {
+    x: f64,
+    y: f64,
+}
+
+impl Vec2 {
+    fn add(&self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+
+    fn scale(&self, scalar: f64) -> Vec2 {
+        Vec2 {
+            x: self.x * scalar,
+            y: self.y * scalar,
+        }
+    }
+
+    fn length_squared(&self) -> f64 {
+        self.x * self.x + self.y * self.y
+    }
+}
+
+#[derive(Debug)]
+struct Body {
+    position: Vec2,
+    velocity: Vec2,
+    force: Vec2,
+    mass: f64,
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        let mut rng = rand::thread_rng();
+
+        Self {
+            position: Vec2 {
+                x: rng.gen_range(-10.0..10.0),
+                y: rng.gen_range(-10.0..10.0),
+            },
+            velocity: Vec2 { x: 0.0, y: 0.0 },
+            force: Vec2 { x: 0.0, y: 0.0 },
+            mass: rng.gen_range(1.0..100.0),
+        }
+    }
+}
+
+#[no_mangle]
+fn update_position(bodies: &mut [Body], time_quantum: f64) {
+    for body in bodies.iter_mut() {
+        let new_velocity = body.force.scale(time_quantum / body.mass);
+        body.position = body
+            .position
+            .add(body.velocity.add(new_velocity).scale(time_quantum / 2.0));
+        body.velocity = new_velocity;
+    }
+}
+
+fn simulate(bodies: &mut [Body], nsteps: i32, time_quantum: f64) {
+    for _ in 0..nsteps {
+        update_position(bodies, time_quantum);
+    }
+}
+
+fn main() {
+    let nbodies = 1000;
+    let mut bodies: Vec<Body> = (0..nbodies).map(|_| Body::default()).collect();
+
+    let time_quantum = 0.1;
+    let nsteps = 10_000;
+
+    simulate(&mut bodies, nsteps, time_quantum);
+
+    for (i, body) in bodies.iter().enumerate() {
+        println!(
+            "Body {}: Position: ({:.2}, {:.2})",
+            i, body.position.x, body.position.y
+        );
+    }
+}


### PR DESCRIPTION
looking at different outputs of llvm-ir, opt0 vs opt1 vs opt2 vs opt3. 
- Structs are not optimized at all with opt0 flag, opt1 flag optimizes the struct by removing local storage code for struct fields
- compiler can be smart enough to apply instructions that are computing a memory address using the same arithmetic that a MOV instruction uses. But unlike the MOV instruction, the LEA instruction just stores the computed address in its target register, instead of loading the contents of that address and storing it